### PR TITLE
Update `actions/checkout` in GitHub Actions workflows to 3.x

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: arduino/arduino-lint-action@v1
         with:
           project-type: library


### PR DESCRIPTION
A new major version series of the `actions/checkout` GitHub Action action was started in March 2022:

https://github.com/actions/checkout/releases/tag/v3.0.0

This project's GitHub Actions workflows previously used the `v2` [major version ref](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions#:~:text=example%2C%20v1.1.3%20%E2%80%93-,and%20keeping%20major,-(v1)%20and) when specifying the version of the action to use, resulting in the workflows not having access to the advancements made to the action in the 3.x series.

One of these advancements is the update from using Node.js 12.x to Node.js 16.x for the action on the GitHub Actions runner. GitHub has deprecated the use of Node.js 12.x in actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

In order to encourage the migration of actions and workflows, GitHub added warnings to the workflow run summary page of every GitHub actions workflow that uses a Node.js 12.x-based action:

https://github.com/ArminJo/arduino-test-compile/issues/32#issuecomment-1288151164

Updating the action resolves the warnings. I have carefully evaluated the changes which caused the major version bump in the action and found that they do not have any impact on the functionality of this project's workflows.